### PR TITLE
Feature/error hand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Spring AOP -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+		</dependency>
+		<!-- AspectJ -->
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjweaver</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/aspect/ErrorAspect.java
+++ b/src/main/java/com/example/aspect/ErrorAspect.java
@@ -1,0 +1,21 @@
+package com.example.aspect;
+
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@Slf4j
+public class ErrorAspect {
+	@AfterThrowing(value = "execution(* *..*..*(..)) &&"
+			+ "(bean(*Controller) || bean(*Service) || bean(*Repository))", throwing = "ex")
+	public void throwingNull(DataAccessException ex) {
+		// 例外処理の内容 今回はログ出力
+		log.error("DataAccessExceptionが発生しました");
+	}
+
+}

--- a/src/main/java/com/example/aspect/GlobalControllAdvice.java
+++ b/src/main/java/com/example/aspect/GlobalControllAdvice.java
@@ -1,0 +1,41 @@
+package com.example.aspect;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalControllAdvice {
+
+	/* データベース関連の例外処理 */
+	@ExceptionHandler(DataAccessException.class)
+	public String dataAccessExceptionHandler(DataAccessException e, Model model) {
+		// 空文字をセット
+		model.addAttribute("error", "");
+
+		// メッセージをModelに登録する
+		model.addAttribute("message", "DataAccessExceptionが発生しました");
+
+		// HTTPのエラーコード(500)をModelに登録
+		model.addAttribute("status", HttpStatus.INTERNAL_SERVER_ERROR);
+
+		return "error";
+	}
+
+	/* その他の例外処理 */
+	@ExceptionHandler(Exception.class)
+	public String exceptionHandler(Exception e, Model model) {
+		// 空文字をセット
+		model.addAttribute("error", "");
+
+		// メッセージをModelに登録する
+		model.addAttribute("message", "Exceptionが発生しました");
+
+		// HTTPのエラーコード(500)をModelに登録
+		model.addAttribute("status", HttpStatus.INTERNAL_SERVER_ERROR);
+
+		return "error";
+	}
+}

--- a/src/main/java/com/example/aspect/LogAspect.java
+++ b/src/main/java/com/example/aspect/LogAspect.java
@@ -1,7 +1,9 @@
 package com.example.aspect;
 
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
@@ -27,5 +29,33 @@ public class LogAspect {
 	@After("execution(* *..*.*UserService.*(..))")
 	public void endLog(JoinPoint jp) {
 		log.info("メソッド終了:" + jp.getSignature());
+	}
+
+	/*
+	 * コントローラー全ての実行前後にログを出力する 以下でbeanとアノテーションの直接指定もいける
+	 */
+	// @Around("bean(*Controller*)")
+	// @Around("@annotation(org.springframework.web.bind.annotation.GetMapping)")
+	@Around("@within(org.springframework.stereotype.Controller)")
+	public Object startLog(ProceedingJoinPoint jp) throws Throwable {
+		// 開始ログ出力
+		log.info("メソッド開始:" + jp.getSignature());
+
+		try {
+			// メソッド実行
+			Object result = jp.proceed();
+
+			// 終了ログ出力
+			log.info("メソッド終了:" + jp.proceed());
+
+			// 実行結果を呼び出し元に返却する
+			return result;
+		} catch (Exception e) {
+			// エラーログ出力
+			log.error("メソッド異常終了:" + jp.getSignature());
+
+			// エラーを再度スローする
+			throw e;
+		}
 	}
 }

--- a/src/main/java/com/example/aspect/LogAspect.java
+++ b/src/main/java/com/example/aspect/LogAspect.java
@@ -1,0 +1,31 @@
+package com.example.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@Slf4j
+public class LogAspect {
+
+	/*
+	 * サービスの実行前にログ出力する. 対象:[UserService]をクラス名に含んでいるもの
+	 */
+	@Before("execution(* *..*.*UserService.*(..))")
+	public void startLog(JoinPoint jp) {
+		log.info("メソッド開始:" + jp.getSignature());
+	}
+
+	/*
+	 * サービスの実行後にログ出力する. 対象:[UserService]をクラス名に含んでいるもの
+	 */
+	@After("execution(* *..*.*UserService.*(..))")
+	public void endLog(JoinPoint jp) {
+		log.info("メソッド終了:" + jp.getSignature());
+	}
+}

--- a/src/main/java/com/example/controller/SignupController.java
+++ b/src/main/java/com/example/controller/SignupController.java
@@ -5,10 +5,13 @@ import java.util.Map;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,4 +70,35 @@ public class SignupController {
 		// ログイン画面にリダイレクトする
 		return "redirect:/login";
 	};
+
+	/* データベース関連の例外処理 */
+	@ExceptionHandler(DataAccessException.class)
+	public String dataAccessExceptionHandler(DataAccessException e, Model model) {
+		// 空文字をセット
+		model.addAttribute("error", "");
+
+		// メッセージをModelに登録する
+		model.addAttribute("message", "SignupControllerで例外が発生しました");
+
+		// HTTPのエラーコード(500)をModelに登録する
+		model.addAttribute("status", HttpStatus.INTERNAL_SERVER_ERROR);
+
+		return "error";
+	};
+
+	/* その他の例外処理 */
+	@ExceptionHandler(Exception.class)
+	public String exceptionHandler(Exception e, Model model) {
+		// 空文字をセット
+		model.addAttribute("error", "");
+
+		// メッセージをModelに登録する
+		model.addAttribute("message", "SignupControllerで例外が発生しました");
+
+		// HTTPのエラーコード(500)をModelに登録する
+		model.addAttribute("status", HttpStatus.INTERNAL_SERVER_ERROR);
+
+		return "error";
+	};
+
 }

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>Error</title>
+</head>
+<body>
+	<h1 th:text="${status} + '' + ${error}"></h1>
+	<p th:text="${message}"></p>
+	<p>ログイン画面に戻ってください</p>
+	<form th:action="@{/logout}" method="post">
+		<button class="btn btn-link" type="submit">ログイン画面に戻る</button>
+	</form>
+</body>
+</html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0,shrink-to-fit=no">
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" />
+	
+	<script th:src="@{/webjars/jquery/jquery.min.js}"></script>
+	<script th:src="@{/webjars/bootstrap/js/bootstrap.min.js}"></script>
+<title>404 Error</title>
+</head>
+<body>
+	<h1 th:text="${status} + '' + ${error}" class="display-1 text-center"></h1>
+	<p class="text-center">お探しのページは見つかりませんでした</p>
+	<form th:action="@{/logout}" method="post">
+		<button class="btn btn-secondary d-block mx-auto " type="submit">ログイン画面に戻る</button>
+	</form>
+</body>
+</html>


### PR DESCRIPTION
### Why
- 実装背景
  - WhiteLabelErrorなどの表記はエラー内容が表示されてしまうセキュリティの問題が発生することやユーザーが何をしたら良いか分からなくなる(ユーザビリティの改善)ため**エラー画面と例外処理の実装**
### What
- 実装内容
  - 共通エラー画面の実装
  - httpエラー毎のエラー画面
  - コントローラークラスごとの例外処理
  - Webアプリケーション全体での例外処理

## Ref
- [共通エラー画面](https://gyazo.com/8dd0c5dc1d04cfee2e0f75205fd0e470)
- [httpエラー画面](https://gyazo.com/ce316b6ebe0f8b2173beebb12c6d68ef)
- [コントローラークラスごとの例外処理](https://gyazo.com/f2dbdf2ea9c1949c96b6e4b764c4a933)
- [Webアプリ全体での例外処理](https://gyazo.com/112d515d8cdd6489720f436bec5008bd)
## Check
- [x] issueのタスクが全て消化できているか(その1)
- [x] issueがマージ後に閉じれる状況か(その2) 
