### PR TITLE
Feature/security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
-		<!-- thymeleaf-layout-dialect -->
+		<!-- SpringSecurity -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<!-- Thymeleaf拡張ライブラリ(セキュリティ) -->
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity5</artifactId>
+		</dependency>
+		<!-- Thymeleaf-layout-dialect -->
 		<dependency>
 			<groupId>nz.net.ultraq.thymeleaf</groupId>
 			<artifactId>thymeleaf-layout-dialect</artifactId>

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.example.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	/* セキュリティーの対象外を設定 */
+	@Override
+	public void configure(WebSecurity web) throws Exception {
+		// セキュリティ適用外
+		web.ignoring().antMatchers("/webjars/**").antMatchers("/css/**").antMatchers("/js/**")
+				.antMatchers("/h2-console/**");
+	}
+
+	/* セキュリティの各種設定 */
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		// ログインが不要ページの設定(適用外)
+		http.authorizeRequests().antMatchers("/login").permitAll()// 直リンク遷移OK
+				.antMatchers("/user/signup").permitAll()// 直リンク遷移OK
+				.anyRequest().authenticated(); // それ以外は直リンク遷移NG
+
+		// csrf対策を一時的に無効に設定
+		http.csrf().disable();
+	}
+}

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @EnableWebSecurity
 @Configuration
@@ -47,6 +48,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.usernameParameter("userId")// ログインページのユーザーID
 				.passwordParameter("password")// ログインページのパスワード
 				.defaultSuccessUrl("/user/list", true); // 成功時の遷移先
+
+		// ログアウト処理
+		http.logout().logoutRequestMatcher(new AntPathRequestMatcher("/logout")).logoutUrl("/logout")
+				.logoutSuccessUrl("/login?logout");
 
 		// csrf対策を一時的に無効に設定
 		http.csrf().disable();

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -7,12 +8,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Autowired
+	private UserDetailsService userDetailsService;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -53,8 +58,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		PasswordEncoder encoder = passwordEncoder();
 
 		// インメモリ認証
-		auth.inMemoryAuthentication().withUser("user")// userを追加
-				.password(encoder.encode("user")).roles("GENERAL").and().withUser("admin")// adminを追加
-				.password(encoder.encode("admin")).roles("ADMIN");
+		/*
+		 * auth.inMemoryAuthentication().withUser("user")// userを追加
+		 * .password(encoder.encode("user")).roles("GENERAL").and().withUser("admin")//
+		 * adminを追加 .password(encoder.encode("admin")).roles("ADMIN");
+		 */
+
+		// ユーザーデータで認証する
+		auth.userDetailsService(userDetailsService).passwordEncoder(encoder);
 	}
 }

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,15 +1,23 @@
 package com.example.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
 	/* セキュリティーの対象外を設定 */
 	@Override
@@ -42,9 +50,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	/* 認証の設定 */
 	@Override
 	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+		PasswordEncoder encoder = passwordEncoder();
+
 		// インメモリ認証
 		auth.inMemoryAuthentication().withUser("user")// userを追加
-				.password("user").roles("GENERAL").and().withUser("admin")// adminを追加
-				.password("admin").roles("ADMIN");
+				.password(encoder.encode("user")).roles("GENERAL").and().withUser("admin")// adminを追加
+				.password(encoder.encode("admin")).roles("ADMIN");
 	}
 }

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		// ログインが不要ページの設定(適用外)
 		http.authorizeRequests().antMatchers("/login").permitAll()// 直リンク遷移OK
 				.antMatchers("/user/signup").permitAll()// 直リンク遷移OK
+				.antMatchers("/admin").hasAnyAuthority("ROLE_ADMIN")// 権限制御
 				.anyRequest().authenticated(); // それ以外は直リンク遷移NG
 
 		// ログイン処理
@@ -54,7 +55,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.logoutSuccessUrl("/login?logout");
 
 		// csrf対策を一時的に無効に設定
-		http.csrf().disable();
+		// http.csrf().disable();
 	}
 
 	/* 認証の設定 */

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -36,5 +37,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 		// csrf対策を一時的に無効に設定
 		http.csrf().disable();
+	}
+
+	/* 認証の設定 */
+	@Override
+	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+		// インメモリ認証
+		auth.inMemoryAuthentication().withUser("user")// userを追加
+				.password("user").roles("GENERAL").and().withUser("admin")// adminを追加
+				.password("admin").roles("ADMIN");
 	}
 }

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -26,6 +26,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.antMatchers("/user/signup").permitAll()// 直リンク遷移OK
 				.anyRequest().authenticated(); // それ以外は直リンク遷移NG
 
+		// ログイン処理
+		http.formLogin().loginProcessingUrl("/login")// ログイン処理のパス login.htmlのth:action="@{****}"
+				.loginPage("/login")// ログインページの指定 loginController の@GetMapping("*****")
+				.failureUrl("/login?error")// ログイン失敗時の遷移先
+				.usernameParameter("userId")// ログインページのユーザーID
+				.passwordParameter("password")// ログインページのパスワード
+				.defaultSuccessUrl("/user/list", true); // 成功時の遷移先
+
 		// csrf対策を一時的に無効に設定
 		http.csrf().disable();
 	}

--- a/src/main/java/com/example/controller/AdminController.java
+++ b/src/main/java/com/example/controller/AdminController.java
@@ -1,0 +1,13 @@
+package com.example.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AdminController {
+	/* アドミン権限専用ページに遷移させる */
+	@GetMapping("/admin")
+	public String getAdmin() {
+		return "admin/admin";
+	}
+}

--- a/src/main/java/com/example/domain/user/service/UserService.java
+++ b/src/main/java/com/example/domain/user/service/UserService.java
@@ -19,4 +19,7 @@ public interface UserService {
 
 	// ユーザー取得(1件)
 	public void deleteUserOne(String userId);
+
+	// ログインユーザー情報取得
+	public MUser getLoginUser(String userId);
 }

--- a/src/main/java/com/example/domain/user/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/domain/user/service/impl/UserDetailsServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.domain.user.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.example.domain.user.model.MUser;
+import com.example.domain.user.service.UserService;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	@Autowired
+	private UserService service;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		// ユーザー情報取得
+		MUser loginUser = service.getLoginUser(username);
+
+		// ユーザーが存在しない場合の処理
+		if (loginUser == null) {
+			throw new UsernameNotFoundException("user not found");
+		}
+
+		// 権限リストを作成
+		GrantedAuthority authority = new SimpleGrantedAuthority(loginUser.getRole());
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(authority);
+
+		// UserDetails生成
+		UserDetails userDetails = (UserDetails) new User(loginUser.getUserId(), loginUser.getPassword(), authorities);
+		return userDetails;
+	}
+}

--- a/src/main/java/com/example/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/domain/user/service/impl/UserServiceImpl.java
@@ -24,7 +24,7 @@ public class UserServiceImpl implements UserService {
 	@Override
 	public void signup(MUser user) {
 		user.setDepartmentId(1); // 部署
-		user.setRole("ROLE_GENGERAL"); // ロール
+		user.setRole("ROLE_GENERAL"); // ロール
 
 		// パスワードの暗号化
 		String rawPassword = user.getPassword();

--- a/src/main/java/com/example/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/domain/user/service/impl/UserServiceImpl.java
@@ -64,4 +64,10 @@ public class UserServiceImpl implements UserService {
 	public void deleteUserOne(String userId) {
 		int count = mapper.deleteOne(userId);
 	}
+
+	/* ログインユーザー情報取得 */
+	@Override
+	public MUser getLoginUser(String userId) {
+		return mapper.findLoginUser(userId);
+	}
 }

--- a/src/main/java/com/example/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/domain/user/service/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.domain.user.service.impl;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,11 +17,19 @@ public class UserServiceImpl implements UserService {
 	@Autowired
 	private UserMapper mapper;
 
+	@Autowired
+	private PasswordEncoder encoder;
+
 	/* ユーザー登録処理 */
 	@Override
 	public void signup(MUser user) {
 		user.setDepartmentId(1); // 部署
 		user.setRole("ROLE_GENGERAL"); // ロール
+
+		// パスワードの暗号化
+		String rawPassword = user.getPassword();
+		user.setPassword(encoder.encode(rawPassword));
+
 		mapper.insertOne(user);
 	}
 
@@ -40,7 +49,12 @@ public class UserServiceImpl implements UserService {
 	@Transactional
 	@Override
 	public void updateUserOne(String userId, String password, String userName) {
-		mapper.updateOne(userId, password, userName);
+
+		// パスワード暗号化
+		String encryptPassword = encoder.encode(password);
+
+		mapper.updateOne(userId, encryptPassword, userName);
+
 		/*
 		 * トランザクション挙動確認の例外発生用 int i = 1 / 0;
 		 */ }

--- a/src/main/java/com/example/repository/UserMapper.java
+++ b/src/main/java/com/example/repository/UserMapper.java
@@ -24,4 +24,8 @@ public interface UserMapper {
 
 	/* ユーザー削除(1件) */
 	public int deleteOne(@Param("userId") String userId);
+
+	/* ログインユーザー取得 */
+	public MUser findLoginUser(String userId);
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql
 
 #Remove the dependency cycle between beans.
-#spring.main.allow-circular-references = true
+spring.main.allow-circular-references = true
 
 #H2DB
 spring.h2.console.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,9 @@ spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql
 
+#Remove the dependency cycle between beans.
+#spring.main.allow-circular-references = true
+
 #H2DB
 spring.h2.console.enabled=true
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,7 +10,7 @@ INSERT INTO m_user(
 	gender,
 	department_id,
 	role
-)VALUES('system@co.jp','password','システム管理者','2000-01-01',21,1,1,'ROLE_ADMIN'),('user@co.jp','password','ユーザー1','2000-01-01',21,2,2,'ROLE_GENERAL');
+)VALUES('system@co.jp','$2a$10$HoHA7jJXPWKPU8S8ULOdfeoFGV1g2S7EnEG0etVBMq024AWcEl0za','システム管理者','2000-01-01',21,1,1,'ROLE_ADMIN'),('user@co.jp','$2a$10$HoHA7jJXPWKPU8S8ULOdfeoFGV1g2S7EnEG0etVBMq024AWcEl0za','ユーザー1','2000-01-01',21,2,2,'ROLE_GENERAL');
 /*部署マスタ*/
 INSERT INTO m_department(
 	department_id,

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -8,3 +8,12 @@ age=年齢
 male=男性
 female=女性
 gender=性別
+
+#===================
+#ログイン失敗メッセージ
+#===================
+AbstractUserDetailsAuthenticationProvider.locked=アカウントはロックされています
+AbstractUserDetailsAuthenticationProvider.disabled=アカウントは使用できません
+AbstractUserDetailsAuthenticationProvider.expired=アカウントの有効期限が切れています
+AbstractUserDetailsAuthenticationProvider.credentialsExpired=パスワードの有効期限が切れています
+AbstractUserDetailsAuthenticationProvider.badCredentials=IDまたはパスワードが間違っています

--- a/src/main/resources/mapper/h2/UserMapper.xml
+++ b/src/main/resources/mapper/h2/UserMapper.xml
@@ -107,5 +107,14 @@
 		m_user
 	where
 		user_id = #{userId}
-	</delete>	
+	</delete>
+	<!--ログインユーザー情報取得  -->
+	<select id="findLoginUser" resultType="MUser">
+		select
+			*
+		from
+			m_user
+		where
+			user_id = #{userId}
+	</select>
 </mapper>

--- a/src/main/resources/templates/admin/admin.html
+++ b/src/main/resources/templates/admin/admin.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+<meta charset="UTF-8">
+<title>アドミン権限専用</title>
+</head>
+<body>
+	<div layout:fragment="content">
+		<div class="header border-bottom mt-2">
+			<h1 class="h2">アドミン権限専用画面</h1>
+		</div>
+	</div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/menu.html
+++ b/src/main/resources/templates/layout/menu.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http:://www.thymeleaf.org" xmlns:layout="http:://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<html xmlns:th="http:://www.thymeleaf.org" xmlns:layout="http:://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
 </head>
 <body>
@@ -8,7 +8,7 @@
 			<li role="presentation">
 				<a th:href="@{'/user/list'}" class="nav-link">ユーザ一覧</a>
 			</li>
-			<li role="presentation">
+			<li role="presentation" sec:authorize="hasRole('ADMIN')">
 			<a th:href="@{'/admin'}" class="nav-link">アドミン専用</a>
 			</li>
 		</ul>

--- a/src/main/resources/templates/layout/menu.html
+++ b/src/main/resources/templates/layout/menu.html
@@ -6,9 +6,10 @@
 	<div layout:fragment="menu" class="bg-light">
 		<ul class="nav nav-pills nav-stacked">
 			<li role="presentation">
-				<a th:href="@{'/user/list'}" class="nav-link">
-					ユーザ一覧
-				</a>
+				<a th:href="@{'/user/list'}" class="nav-link">ユーザ一覧</a>
+			</li>
+			<li role="presentation">
+			<a th:href="@{'/admin'}" class="nav-link">アドミン専用</a>
 			</li>
 		</ul>
 	</div>

--- a/src/main/resources/templates/login/login.html
+++ b/src/main/resources/templates/login/login.html
@@ -16,6 +16,7 @@
 	<div class="text-center">
 		<form method="post" th:action="@{/login}" class="form-login">
 		 	<h2>ログイン</h2>
+		 	<p th:if="${session['SPRING_SECURITY_LAST_EXCEPTION']}!= null" th:text="${session['SPRING_SECURITY_LAST_EXCEPTION'].message}" class="text-danger">ログインエラーメッセージ</p>
 		 	<!-- ユーザーID -->
 		 	<div class="form-group">
 		 		<label for="userId" class="sr-only">userId</label>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -54,6 +54,7 @@
 		</div>
 		<!-- 登録ボタン -->
 		<input type="submit" th:value="#{user.signup.btn}" class="btn btn-primary w-100 mt-3" />
+		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 	</form>
 	
 </body>


### PR DESCRIPTION
### Why
- 実装背景
  - Springセキュリティーを用いてCSRF対策などのセキュリティ処理を学ぶ
### What
- 実装内容
  - 直リンク遷移の禁止(共通エラー画面表示)
  - ログイン処理
  -  インメモリ認証(ユーザーデータでのログインを使用したためコメントアウト済み)
  -  passwordの暗号化
  - ユーザーデータ認証
  - ログアウト処理(遷移目的で事前作成済みのLogoutControllerは不要になりましたが一旦残してます)
  - CSRF対策
  - URLの認可
  - 画面表示の認可

## Ref
- [issue16](https://github.com/m-suzuki0905/springboot_Kaitai-Shinsho/issues/16)
- [一旦保留のissue21](https://github.com/m-suzuki0905/springboot_Kaitai-Shinsho/issues/21)
- 実装のイメージやスクショ
  -  [アドミン権限](https://gyazo.com/052f6e0cbac4047b5b351601732e19b3)
  - [一般ユーザー](https://gyazo.com/94654ed6b3e2edd792ab695908030a8c)
  - [passwordの暗号化](https://gyazo.com/37df63a6dea807e928306e316d28277e)
  - [URLの認可と直リンクの禁止](https://gyazo.com/b03db8569afaf13c038170586bc43bb1)



## Check
- [ ] issueのタスクが全て消化できているか(その1)
- [ ] issueがマージ後に閉じれる状況か(その2) 
