### PR TITLE
Feature/rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,19 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- Datatables -->
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>datatables</artifactId>
+			<version>1.10.21</version>
+		</dependency>
+		<!-- datatables-plugins -->
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>datatables-plugins</artifactId>
+			<version>1.10.21</version>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		// ログインが不要ページの設定(適用外)
 		http.authorizeRequests().antMatchers("/login").permitAll()// 直リンク遷移OK
 				.antMatchers("/user/signup").permitAll()// 直リンク遷移OK
+				.antMatchers("/user/signup/rest").permitAll()// 直リンク遷移OK
 				.antMatchers("/admin").hasAnyAuthority("ROLE_ADMIN")// 権限制御
 				.anyRequest().authenticated(); // それ以外は直リンク遷移NG
 

--- a/src/main/java/com/example/rest/RestResult.java
+++ b/src/main/java/com/example/rest/RestResult.java
@@ -1,0 +1,18 @@
+package com.example.rest;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RestResult {
+	/* リターンコード */
+	private int result;
+
+	/*
+	 * エラーマップ key:フィールド名 value:エラーメッセージ
+	 */
+	private Map<String, String> errors;
+}

--- a/src/main/java/com/example/rest/UserRestController.java
+++ b/src/main/java/com/example/rest/UserRestController.java
@@ -1,6 +1,7 @@
 package com.example.rest;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -11,6 +12,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +23,7 @@ import com.example.domain.user.service.UserService;
 import com.example.form.GroupOrder;
 import com.example.form.SignupForm;
 import com.example.form.UserDetailForm;
+import com.example.form.UserListForm;
 
 @RestController
 @RequestMapping("/user")
@@ -33,6 +36,17 @@ public class UserRestController {
 
 	@Autowired
 	private MessageSource messageSource;
+
+	/* ユーザーを検索 */
+	@GetMapping("/get/list")
+	public List<MUser> getUserList(UserListForm form) {
+		// formをMUserクラスに変換する
+		MUser user = modelMapper.map(form, MUser.class);
+
+		// ユーザー一覧取得
+		List<MUser> userList = userService.getUsers(user);
+		return userList;
+	}
 
 	/* ユーザー登録 */
 	@PostMapping("/signup/rest")

--- a/src/main/java/com/example/rest/UserRestController.java
+++ b/src/main/java/com/example/rest/UserRestController.java
@@ -1,12 +1,25 @@
 package com.example.rest;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.domain.user.model.MUser;
 import com.example.domain.user.service.UserService;
+import com.example.form.GroupOrder;
+import com.example.form.SignupForm;
 import com.example.form.UserDetailForm;
 
 @RestController
@@ -14,6 +27,36 @@ import com.example.form.UserDetailForm;
 public class UserRestController {
 	@Autowired
 	private UserService userService;
+
+	@Autowired
+	private ModelMapper modelMapper;
+
+	@Autowired
+	private MessageSource messageSource;
+
+	/* ユーザー登録 */
+	@PostMapping("/signup/rest")
+	public RestResult postSignup(@Validated(GroupOrder.class) SignupForm form, BindingResult bindingResult,
+			Locale locale) {
+		// 入力チェック結果
+		if (bindingResult.hasErrors()) {
+			// チェック結果:NG
+			Map<String, String> errors = new HashMap<>();
+			// エラーメッセージ取得
+			for (FieldError error : bindingResult.getFieldErrors()) {
+				String message = messageSource.getMessage(error, locale);
+				errors.put(error.getField(), message);
+			}
+			// エラー結果の返却
+			return new RestResult(90, errors);
+		}
+		// formをMUserクラスに変換
+		MUser user = modelMapper.map(form, MUser.class);
+		// ユーザー登録
+		userService.signup(user);
+		// 結果の返却
+		return new RestResult(0, null);
+	}
 
 	/* ユーザーを更新する */
 	@PutMapping("/update")

--- a/src/main/java/com/example/rest/UserRestController.java
+++ b/src/main/java/com/example/rest/UserRestController.java
@@ -1,0 +1,34 @@
+package com.example.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.domain.user.service.UserService;
+import com.example.form.UserDetailForm;
+
+@RestController
+@RequestMapping("/user")
+public class UserRestController {
+	@Autowired
+	private UserService userService;
+
+	/* ユーザーを更新する */
+	@PutMapping("/update")
+	public int updateUser(UserDetailForm form) {
+		// ユーザーを更新
+		userService.updateUserOne(form.getUserId(), form.getPassword(), form.getUserName());
+		return 0;
+	}
+
+	/* ユーザーを削除 */
+	@DeleteMapping("/delete")
+	public int deleteUser(UserDetailForm form) {
+		// ユーザーを削除
+		userService.deleteUserOne(form.getUserId());
+
+		return 0;
+	}
+}

--- a/src/main/resources/static/js/user/detail.js
+++ b/src/main/resources/static/js/user/detail.js
@@ -1,0 +1,74 @@
+"use strict";
+
+/*画面ロード時の処理*/
+jQuery(function ($) {
+  /*更新ボタンを押した時の処理*/
+  $("#btn-update").click(function (event) {
+    //ユーザー更新
+    updateUser();
+  });
+
+  /*削除ボタンを押した時の処理*/
+  $("#btn-delete").click(function (event) {
+    //ユーザー削除
+    deleteUser();
+  });
+});
+
+/*ユーザー更新処理*/
+function updateUser() {
+  //フォームの値を取得
+  var formData = $("#user-detail-form").serializeArray();
+
+  //ajax通信
+  $.ajax({
+    type: "PUT",
+    cache: false,
+    url: "/user/update",
+    data: formData,
+    dataType: "json",
+  })
+    .done(function (data) {
+      //ajax通信成功時の処理
+      alert("ユーザーを更新しました");
+
+      //ユーザー一覧画面にリダイレクト
+      window.location.href = "/user/list";
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+      //ajax通信失敗時の処理
+      alert("ユーザー更新に失敗しました");
+    })
+    .always(function () {
+      //常に実行する
+    });
+}
+
+/*ユーザー削除処理*/
+function deleteUser() {
+  //フォームの値を取得
+  var formData = $("#user-detail-form").serializeArray();
+
+  //ajax通信
+  $.ajax({
+    type: "DELETE",
+    cache: false,
+    url: "/user/delete",
+    data: formData,
+    dataType: "json",
+  })
+    .done(function (data) {
+      //ajax通信成功時の処理
+      alert("ユーザーを削除しました");
+
+      //ユーザー一覧画面にリダイレクト
+      window.location.href = "/user/list";
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+      //ajax通信失敗時の処理
+      alert("ユーザー削除に失敗しました");
+    })
+    .always(function () {
+      //常に実行する
+    });
+}

--- a/src/main/resources/static/js/user/list.js
+++ b/src/main/resources/static/js/user/list.js
@@ -1,0 +1,102 @@
+"use strict";
+
+var userData = null; //ユーザーデータ
+var table = null; //DataTablesオブジェクト
+
+/*画面ロード時の処理*/
+jQuery(function ($) {
+  //DataTablesの初期化
+  createDataTables();
+
+  /*検索ボタンを押した時の処理*/
+  $("#btn-search").click(function (event) {
+    //検索
+    search();
+  });
+});
+
+/*検索処理*/
+function search() {
+  //formの値を取得
+  var formData = $("#user-search-form").serialize();
+
+  //ajax通信
+  $.ajax({
+    type: "GET",
+    url: "/user/get/list",
+    data: formData,
+    dataType: "json",
+    contentType: "application/json; charset=UTF-8",
+    cache: false,
+    timeout: 5000,
+  })
+    .done(function (data) {
+      //ajax通信成功時の処理
+      console.log(data);
+      //JSONを変数に格納
+      userData = data;
+      //DataTables作成
+      createDataTables();
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+      //ajax通信失敗時の処理
+      alert("検索処理に失敗しました");
+    })
+    .always(function () {
+      //常に実行する
+    });
+}
+
+/*DataTables作成*/
+function createDataTables() {
+  //既にDataTablesがあるか確認
+  if (table !== null) {
+    //DataTables破棄
+    table.destroy();
+  }
+
+  //DataTables作成
+  table = $("#user-list-table").DataTable({
+    //日本語化
+    language: {
+      url: "/webjars/datatables-plugins/i18n/Japanese.json",
+    },
+    //データをセット
+    data: userData,
+    //データと列をマッピング
+    columns: [
+      { data: "userId" },
+      { data: "userName" },
+      {
+        data: "birthday",
+        render: function (data, type, row) {
+          var date = new Date(data);
+          var year = date.getFullYear();
+          var month = date.getMonth() + 1;
+          var date = date.getDate();
+          return year + "/" + month + "/" + date;
+        },
+      },
+      { data: "age" },
+      {
+        data: "gender",
+        render: function (data, type, row) {
+          var gender = "";
+          if (data === 1) {
+            gender = "男性";
+          } else {
+            gender = "女性";
+          }
+          return gender;
+        },
+      },
+      {
+        data: "userId",
+        render: function (data, type, row) {
+          var url = '<a href="/user/detail/' + data + ">詳細</a>";
+          return url;
+        },
+      },
+    ],
+  });
+}

--- a/src/main/resources/static/js/user/signup.js
+++ b/src/main/resources/static/js/user/signup.js
@@ -1,0 +1,78 @@
+"use strict";
+
+/*画面ロード時の処理*/
+jQuery(function ($) {
+  // 登録ボタンを押した時の処理
+  $("#btn-signup").click(function (event) {
+    //ユーザー登録
+    signupUser();
+  });
+});
+
+function signupUser() {
+  //バリデーション結果をクリアする
+  removeValidResult();
+
+  //フォームの値を取得
+  var formData = $("#signup-form").serializeArray();
+
+  //ajax通信
+  $.ajax({
+    type: "POST",
+    cache: false,
+    url: "/user/signup/rest",
+    data: formData,
+    dataType: "json",
+  })
+    .done(function (data) {
+      //ajax通信成功時の処理
+      console.log(data);
+
+      if (data.result === 90) {
+        //validationエラー時の処理
+        $.each(data.errors, function (key, value) {
+          reflectValidResult(key, value);
+        });
+      } else if (data.result === 0) {
+        alert("ユーザーを登録しました");
+        //ログイン画面にリダイレクト
+        window.location.href = "/login";
+      }
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+      //ajax通信失敗時の処理
+      alert("ユーザー登録に失敗しました");
+    })
+    .always(function () {
+      //常に実行
+    });
+}
+
+/*bootstrapのバリデーション結果をクリア*/
+function removeValidResult() {
+  $(".is-invalid").removeClass("is-invalid");
+  $(".invalid-feedback").remove();
+  $("text-danger").remove();
+}
+
+/*bootstrapのバリデーション結果を反映*/
+function reflectValidResult(key, value) {
+  //エラーメッセージ追加
+  if (key === "gender") {
+    //性別パターン
+    //css適用
+    $("input[name=" + key + "]").addClass("is-invalid");
+    //エラーメッセージ追加
+    $("input[name=" + key + "]")
+      .parent()
+      .parent()
+      .append('<div class="text-danger">' + value + "</div>");
+  } else {
+    //性別以外
+    //css適用
+    $("input[id=" + key + "]").addClass("is-invalid");
+    $("input[id=" + key + "]").after(
+      '<div class="invalid-feedback">' + value + "</div>"
+    );
+  }
+}

--- a/src/main/resources/templates/user/detail.html
+++ b/src/main/resources/templates/user/detail.html
@@ -1,86 +1,123 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
-<head>
-<meta charset="UTF-8">
-<title>ユーザー詳細</title>
-<link rel="stylesheet" th:href="@{/css/user/list.css}" />
-</head>
-<body>
-	<div layout:fragment="content">
-		<div class="header border-bottom">
-			<h1 class="h2">ユーザー詳細</h1>
-		</div>
-		<form th:action="@{/user/detail}" method="post" class="form-signup" id="user-detail-form" th:object="${userDetailForm}">
-		<input type="hidden" th:field="*{userId}" />
-			<!-- ユーザー詳細情報 -->
-			<table class="table table-stripedtable-bordered table-hover">
-				<tbody>
-					<tr>
-						<th class="w-25">
-						ユーザーID
-						</th>
-						<td th:text="*{userId}"></td>
-					</tr>
-					<tr>
-						<th>パスワード</th>
-						<td>
-							<input type="text"th:field="*{password}" class="form-controll" />
-						</td>							
-					</tr>
-					<tr>
-						<th>ユーザー名</th>
-							<td>
-								<input type="text" th:field="*{userName}" class="form-controll" />
-							</td>		
-					</tr>
-					<tr>
-						<th>誕生日</th>
-						<td th:text="*{#dates.format(birthday,'YYYY/MM/dd')}"></td>
-					</tr>
-					<tr>
-						<th>年齢</th>
-							<td th:text="*{age}"></td>
-					</tr>
-					<tr>
-						<th>性別</th>
-							<td th:text="*{gender == 1 ? '男性':'女性'}"></td>
-					</tr>
-					<tr>
-						<th>部署名</th>
-						<td>
-						<span th:if="*{department != null}" th:text="*{department.departmentName}"></span>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<!-- ボタンエリア -->
-			<div class="text-center">
-				<!-- 削除ボタン -->
-				<button class="btn btn-danger" type="submit" name="delete">削除</button>
-				<!-- 更新ボタン -->
-				<button class="btn btn-primary" type="submit" name="update">更新</button>
-			</div>
-			<!-- 給料情報 -->
-			<th:block th:if="*{salaryList != null and salaryList.size() > 0}">
-				<div class="header border-bottom">
-					<h1 class="h2">給料</h1>
-				</div>
-				<table class="table table-striped table-bordered table-hover">
-					<thead>
-						<tr>
-							<th class="w-25"></th>
-							<th>給料</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr th:each="item:*{salaryList}">
-							<td th:text="${item.yearMonth}"></td>
-							<td th:text="${#numbers.formatInteger(item.salary,3,'COMMA')}"></td>
-						</tr>
-					</tbody>
-				</table>
-			</th:block>
-		</form>
-	</div>
-</body>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{layout/layout}"
+>
+  <head>
+    <meta charset="UTF-8" />
+    <title>ユーザー詳細</title>
+    <link rel="stylesheet" th:href="@{/css/user/list.css}" />
+    <script th:src="@{/js/user/detail.js}"></script>
+  </head>
+  <body>
+    <div layout:fragment="content">
+      <div class="header border-bottom">
+        <h1 class="h2">ユーザー詳細</h1>
+      </div>
+      <form
+        th:action="@{/user/detail}"
+        method="post"
+        class="form-signup"
+        id="user-detail-form"
+        th:object="${userDetailForm}"
+      >
+        <input type="hidden" th:field="*{userId}" />
+        <!-- ユーザー詳細情報 -->
+        <table class="table table-stripedtable-bordered table-hover">
+          <tbody>
+            <tr>
+              <th class="w-25">ユーザーID</th>
+              <td th:text="*{userId}"></td>
+            </tr>
+            <tr>
+              <th>パスワード</th>
+              <td>
+                <input
+                  type="text"
+                  th:field="*{password}"
+                  class="form-controll"
+                />
+              </td>
+            </tr>
+            <tr>
+              <th>ユーザー名</th>
+              <td>
+                <input
+                  type="text"
+                  th:field="*{userName}"
+                  class="form-controll"
+                />
+              </td>
+            </tr>
+            <tr>
+              <th>誕生日</th>
+              <td th:text="*{#dates.format(birthday,'YYYY/MM/dd')}"></td>
+            </tr>
+            <tr>
+              <th>年齢</th>
+              <td th:text="*{age}"></td>
+            </tr>
+            <tr>
+              <th>性別</th>
+              <td th:text="*{gender == 1 ? '男性':'女性'}"></td>
+            </tr>
+            <tr>
+              <th>部署名</th>
+              <td>
+                <span
+                  th:if="*{department != null}"
+                  th:text="*{department.departmentName}"
+                ></span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <!-- ボタンエリア -->
+        <div class="text-center">
+          <!-- 削除ボタン -->
+          <button class="btn btn-danger" type="submit" name="delete">
+            削除
+          </button>
+          <!-- 更新ボタン -->
+          <button class="btn btn-primary" type="submit" name="update">
+            更新
+          </button>
+        </div>
+        <!-- RESTボタンエリア -->
+        <div class="text-center mt-2">
+          <!-- 削除ボタン -->
+          <button id="btn-delete" class="btn btn-danger" type="button">
+            削除(REST)
+          </button>
+          <!-- 更新ボタン -->
+          <button id="btn-update" class="btn btn-primary" type="button">
+            更新(REST)
+          </button>
+        </div>
+        <!-- 給料情報 -->
+        <th:block th:if="*{salaryList != null and salaryList.size() > 0}">
+          <div class="header border-bottom">
+            <h1 class="h2">給料</h1>
+          </div>
+          <table class="table table-striped table-bordered table-hover">
+            <thead>
+              <tr>
+                <th class="w-25"></th>
+                <th>給料</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr th:each="item:*{salaryList}">
+                <td th:text="${item.yearMonth}"></td>
+                <td
+                  th:text="${#numbers.formatInteger(item.salary,3,'COMMA')}"
+                ></td>
+              </tr>
+            </tbody>
+          </table>
+        </th:block>
+      </form>
+    </div>
+  </body>
 </html>

--- a/src/main/resources/templates/user/list.html
+++ b/src/main/resources/templates/user/list.html
@@ -5,7 +5,10 @@
 <title>
 	ユーザー一覧
 </title>
-<link rel="stylesheet" th:href="@{/css/user.list.css}" />
+<link rel="stylesheet" th:href="@{/css/user/list.css}" />
+<link rel="stylesheet" th:href="@{/webjars/datatables/css/jquery.dataTables.min.css}" />
+<script th:src="@{/webjars/datatables/js/jquery.dataTables.min.js}" defer></script>
+<script th:src="@{/js/user/list.js}" defer></script>
 </head>
 <body>
 	<div layout:fragment="content">
@@ -26,6 +29,7 @@
 					<input type="text" class="form-controll" th:field="*{userName}"/>
 				</div>
 				<button class="btn btn-primary" type="submit">検索</button>
+				<button id="btn-search" class="btn btn-primary ml-3" type="button">検索(REST)</button>
 			</form>
 		</div>
 		<!-- 一覧表示 -->
@@ -53,6 +57,21 @@
 						</td>
 					</tr>
 				</tbody>
+			</table>
+		</div>
+		<!-- 一覧表示(REST) -->
+		<div>
+			<table id="user-list-table" class="table table-striped table-bordered table-hover w-100">
+				<thead class="thead-light">
+					<tr>
+						<th class="th-width">ユーザーID</th>
+						<th class="th-width">ユーザー名</th>
+						<th class="th-width">誕生日</th>
+						<th class="th-width">年齢</th>
+						<th class="th-width">性別</th>
+						<th class="th-width"></th>
+					</tr>
+				</thead>
 			</table>
 		</div>
 	</div>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -5,10 +5,11 @@
 <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 <!-- cssの読み込み -->
 <link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}"/>
-<link rel="stylesheet" th:href="@{css/user/signup.css}"/>
+<link rel="stylesheet" th:href="@{/css/user/signup.css}"/>
 <!-- JSの読み込み -->
 <script th:src="@{/webjars/jquery/jquery.min.js}" defer></script>
 <script th:src="@{/webjars/bootstrap/js/bootstrap.min.js}" defer></script>
+<script th:src="@{/js/user/signup.js}" defer></script>
 
 <title th:text="#{user.signup.title}"></title>
 <body class="bg-light">
@@ -54,8 +55,9 @@
 		</div>
 		<!-- 登録ボタン -->
 		<input type="submit" th:value="#{user.signup.btn}" class="btn btn-primary w-100 mt-3" />
+		<button id="btn-signup" type="button" class="btn btn-primary w-100 mt-3">ユーザー登録(REST)</button>
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 	</form>
-	
+
 </body>
 </html>


### PR DESCRIPTION
### Why
- 実装背景
  -REST通信を実装して処理の向上を図る。フロントとサーバーの開発分離のイメージをつける
### What
- 実装内容
  - 更新・削除 メソッドをRestパラメーターで渡してjQueryのajax通信で再実装
  - 登録・バリデーションも上記と同じでjqueryでバリデーションのレイアウト(BootStrap)をDOM生成
  - 検索 ユーザーリストのフィールドをDataTablesのプラグインを使用してRESTで動的生成

## Ref
- 関連PRへの参照リンク
- [更新](https://gyazo.com/4639284e8fbfb449a3c31d0501b5057a)
- [バリデーション](https://gyazo.com/5791b906a852c6c0f6c3d72bf9e3b06e)
- [検索](https://gyazo.com/f715c1b2f1db28a68f41e2300cfa69e3)
## Check
- [x] issueのタスクが全て消化できているか(その1)
- [x] issueがマージ後に閉じれる状況か(その2) 
